### PR TITLE
Added baloon_obj var to use in setTimeout context

### DIFF
--- a/jquery.balloon.js
+++ b/jquery.balloon.js
@@ -225,9 +225,10 @@
       $target.removeAttr('title');
       if(options.url && !$balloon.data('ajaxDisabled')) {
         clearTimeout($balloon.data('ajaxDelay'));
+        var balloon_obj = this;
         $balloon.data('ajaxDelay',
           setTimeout(function() {
-            $balloon.load($.isFunction(options.url) ? options.url(this) : options.url, function(res, sts, xhr) {
+            $balloon.load($.isFunction(options.url) ? options.url(balloon_obj) : options.url, function(res, sts, xhr) {
               if(sts !== 'success' && sts !== 'notmodified') { return; }
               $balloon.data('ajaxDisabled', true);
               if(options.ajaxContentsMaxAge >= 0) {


### PR DESCRIPTION
Added new var ```balloon_obj``` before entering ```setTimeout``` context.
The call to ```options.url```(when it is a function) using ```this```as parameter was giving an error, since the function may need the element to calculate the url returned value.