### PR TITLE
Fix broken links

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,9 +36,9 @@ Distinct features
 Chrome 49+, Firefox 36+, IE11+, IE Edge, Safari 9.1+, Opera 28+, Android Browser 50+
 
 ## Links
-Detail explanation [here](//urin.github.io/posts/2014/jquery-balloon-js/) (in Japanese).
+Detail explanation [here](//urin.github.io/posts/2014/jquery-balloon-js) (in Japanese).
 
-[jquery.balloon.js - URIN HACK](//urin.github.io/posts/2014/jquery-balloon-js/)
+[jquery.balloon.js - URIN HACK](//urin.github.io/posts/2014/jquery-balloon-js)
 
 Copyright
 ------------------------


### PR DESCRIPTION
Fix the link(s) to the blog article in the README. The URL works without the trailing slash and 404s if it is included.

A better solution would be to fix this in the `_config.yml` for the site, as described [here](https://github.com/jekyll/jekyll/issues/4440), but I can't find one [here](https://github.com/urin/urin.github.com).